### PR TITLE
support nested include for JSON

### DIFF
--- a/lib/representable/bindings/json_bindings.rb
+++ b/lib/representable/bindings/json_bindings.rb
@@ -16,7 +16,7 @@ module Representable
 
     # Represents plain key-value.
     class TextBinding < Binding
-      def write(hash, value)
+      def write(hash, value, operation_mode=nil, operation_hash={})
         hash[definition.from] = value
       end
 
@@ -32,11 +32,11 @@ module Representable
       include Representable::Binding::Hooks # includes #create_object and #write_object.
       include Representable::Binding::Extend
 
-      def write(hash, object)
+      def write(hash, object, operation_mode=nil, operation_hash={})
         if definition.array?
-          hash[definition.from] = object.collect { |obj| serialize(obj) }
+          hash[definition.from] = object.collect { |obj| serialize(obj, operation_mode, operation_hash) }
         else
-          hash[definition.from] = serialize(object)
+          hash[definition.from] = serialize(object, operation_mode, operation_hash)
         end
       end
 
@@ -47,9 +47,15 @@ module Representable
       end
 
     private
-      def serialize(object)
+      def serialize(object, operation_mode, operation_hash)
         return nil if object.nil?
-        write_object(object).to_hash(:wrap => false)
+        options = {wrap: false}
+        if operation_mode == EXCEPT_MODE
+          options[:except] = operation_hash
+        elsif operation_mode == INCLUDE_MODE
+          options[:include] = operation_hash
+        end
+        write_object(object).to_hash(options)
       end
     end
   end

--- a/lib/representable/bindings/xml_bindings.rb
+++ b/lib/representable/bindings/xml_bindings.rb
@@ -23,7 +23,7 @@ module Representable
     
     # Represents a tag attribute.
     class AttributeBinding < Binding
-      def write(xml, values)
+      def write(xml, values, operation_mode=nil, operation_hash={})
         xml[definition.from] = values.to_s
       end
 
@@ -36,7 +36,7 @@ module Representable
     
     # Represents text content in a tag. # FIXME: is this tested???
     class TextBinding < Binding
-      def write(xml, value)
+      def write(xml, value, operation_mode=nil, operation_hash={})
         if definition.array?
           value.each do |v|
             add(xml, definition.from, v)
@@ -66,7 +66,7 @@ module Representable
       include Representable::Binding::Extend
       
       # Adds the ref's markup to +xml+. 
-      def write(xml, object)
+      def write(xml, object, operation_mode=nil, operation_hash={})
         if definition.array?
           object.each do |item|
             write_entity(xml, item)


### PR DESCRIPTION
originally, we can only do one level include, which can't select fields in bands
`.to_hash(include: [:name, :bands])`

this PR will support
`.to_hash(include: [:name, bands: [:name, :artist]])`
